### PR TITLE
Fix MotionSystemDemo to terminate after reaching Demonstration complete!

### DIFF
--- a/src/main/java/com/example/motion/demo/MotionSystemDemo.java
+++ b/src/main/java/com/example/motion/demo/MotionSystemDemo.java
@@ -142,5 +142,6 @@ public class MotionSystemDemo {
         Thread.sleep(1000);
 
         System.out.println("\nDemonstration complete!");
+        System.exit(0);
     }
 }


### PR DESCRIPTION
Add termination statement to MotionSystemDemo after demonstration completion

* Add `System.exit(0)` at the end of the `demonstrateMotionSequence` method in `src/main/java/com/example/motion/demo/MotionSystemDemo.java` to terminate the program after printing "Demonstration complete!".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/scimbe/ExampleLayerInMotion/pull/2?shareId=9123de86-254b-4241-8dfa-20f6d76faebf).