### PR TITLE
Extend MotionController logic with a meaningful demo behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Das Character Motion System implementiert eine dreischichtige Architektur zur Ve
 
 2. Sie sollten eine animierte Oberfläche sehen, die Bewegung, den Wechsel der Motion Layer und die Koordinaten auf einem Gitter anzeigt.
 
+### Zugriff auf die Motion Behavior Demo
+
+1. Öffnen Sie Ihren Webbrowser und navigieren Sie zu:
+   ```
+   http://localhost:8080/demo-motion
+   ```
+
+2. Sie sollten eine Nachricht sehen, die den erfolgreichen Abschluss der Motion Behavior Demo anzeigt.
+
 ## SonarQube Integration
 
 ### Lokale Einrichtung

--- a/src/main/java/com/example/motion/web/MotionController.java
+++ b/src/main/java/com/example/motion/web/MotionController.java
@@ -1,14 +1,72 @@
 package com.example.motion.web;
 
+import com.example.motion.services.ICharacterMotionService;
+import com.example.motion.sys.behavior.AdvancedWalkingLayer;
+import com.example.motion.sys.behavior.BasicWalkingLayer;
+import com.example.motion.sys.model.Direction;
+import com.example.motion.sys.model.Vector3D;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 @RestController
 public class MotionController {
 
+    @Autowired
+    private ICharacterMotionService motionService;
+
     @GetMapping("/animated-surface")
     public String getAnimatedSurface() {
-        // Placeholder for the animated surface logic
-        return "Animated surface showing movement, motion layer switching, and coordinates on a grid.";
+        return "Animated surface showing movement, motion layer switching, and coordinates on a grid. Access the motion behavior demo via /demo-motion endpoint.";
+    }
+
+    @GetMapping("/demo-motion")
+    public String demoMotionBehavior() {
+        try {
+            UUID characterId = UUID.randomUUID();
+            BasicWalkingLayer basicLayer = new BasicWalkingLayer();
+            AdvancedWalkingLayer advancedLayer = new AdvancedWalkingLayer();
+
+            motionService.addMotionLayer(basicLayer, 1);
+            motionService.registerMotionCallback(characterId, (id, state) -> {
+                System.out.printf("Position: %s, Speed: %.2f%n",
+                        state.getPosition(), state.getSpeed());
+            });
+
+            Direction walkDirection = new Direction(new Vector3D(1, 0, 0));
+            motionService.setMovementDirection(characterId, walkDirection, 0.5f).join();
+            Thread.sleep(2000);
+
+            motionService.removeMotionLayer(basicLayer);
+            motionService.addMotionLayer(advancedLayer, 1);
+            Thread.sleep(500);
+
+            advancedLayer.setGaitType(characterId, AdvancedWalkingLayer.GaitType.NORMAL);
+            motionService.setMovementDirection(characterId, walkDirection, 0.5f).join();
+            Thread.sleep(2000);
+
+            advancedLayer.setGaitType(characterId, AdvancedWalkingLayer.GaitType.SNEAKING);
+            motionService.setMovementDirection(characterId, walkDirection, 0.3f).join();
+            Thread.sleep(2000);
+
+            advancedLayer.setGaitType(characterId, AdvancedWalkingLayer.GaitType.LIMPING);
+            motionService.setMovementDirection(characterId, walkDirection, 0.4f).join();
+            Thread.sleep(2000);
+
+            motionService.stopMotion(characterId).join();
+            Thread.sleep(500);
+
+            motionService.removeMotionLayer(advancedLayer);
+            motionService.addMotionLayer(basicLayer, 1);
+            motionService.setMovementDirection(characterId, walkDirection, 0.5f).join();
+            Thread.sleep(2000);
+
+            motionService.stopMotion(characterId).join();
+            return "Motion behavior demo completed successfully!";
+        } catch (Exception e) {
+            return "Error during motion behavior demo: " + e.getMessage();
+        }
     }
 }


### PR DESCRIPTION
Extend the `MotionController` class to demonstrate motion behavior.

* **MotionController.java**
  - Add a new method `demoMotionBehavior` to initiate and demonstrate motion sequences using `ICharacterMotionService`.
  - Update the `getAnimatedSurface` method to return a message indicating that the motion behavior demo can be accessed via the `/demo-motion` endpoint.
  - Inject `ICharacterMotionService` into the `MotionController` class using Spring's `@Autowired` annotation.

* **README.md**
  - Add instructions on accessing the motion behavior demo via the `/demo-motion` endpoint.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/scimbe/ExampleLayerInMotion/pull/5?shareId=3a7c899f-563a-4a8b-8bca-d4ff50ef4fdd).