### PR TITLE
Fix JaCoCo-Konfiguration für Java 23-Kompatibilität

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,8 @@
         <bucket4j.version>8.1.0</bucket4j.version>
         <springdoc.version>2.1.0</springdoc.version>
         <lombok.version>1.18.30</lombok.version>
-        <jacoco.version>0.8.11</jacoco.version>
+        <!-- Aktualisierte JaCoCo-Version, die Java 23 unterstützt -->
+        <jacoco.version>0.8.12</jacoco.version>
         <!-- SonarQube-Ausführung standardmäßig deaktivieren -->
         <sonar.skip>true</sonar.skip>
     </properties>
@@ -168,7 +169,7 @@
                     <includes>
                         <include>**/*Test.java</include>
                     </includes>
-                    <!-- Argumente, um JVM-Warnungen zu unterdrücken -->
+                    <!-- Argumente für JVM -->
                     <argLine>
                         -XX:+EnableDynamicAgentLoading
                         @{argLine}
@@ -188,14 +189,17 @@
                             <goal>prepare-agent</goal>
                         </goals>
                         <configuration>
-                            <!-- Ausschlüsse für problematische Klassen -->
+                            <!-- Erweiterte Ausschlüsse für problematische Klassen -->
                             <excludes>
                                 <exclude>**/com/sun/tools/**</exclude>
                                 <exclude>**/sun/util/resources/**</exclude>
                                 <exclude>**/jdk/internal/**</exclude>
                                 <exclude>**/java/lang/reflect/**</exclude>
                                 <exclude>**/java/lang/instrument/**</exclude>
+                                <exclude>**/java/util/ServiceLoader**</exclude>
                             </excludes>
+                            <!-- Zusätzliche JaCoCo-Eigenschaften -->
+                            <propertyName>argLine</propertyName>
                         </configuration>
                     </execution>
                     <execution>
@@ -225,6 +229,13 @@
             <properties>
                 <sonar.skip>false</sonar.skip>
                 <sonar.host.url>http://localhost:9000</sonar.host.url>
+            </properties>
+        </profile>
+        <!-- Profil zum Überspringen der JaCoCo-Instrumentierung -->
+        <profile>
+            <id>skip-jacoco</id>
+            <properties>
+                <jacoco.skip>true</jacoco.skip>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
## Problem

Die aktuellen Tests schlagen fehl mit dem Fehler:
```
java.lang.IllegalArgumentException: Unsupported class file major version 67
```

Dieses Problem tritt auf, weil JaCoCo 0.8.11 nicht mit Java 23 kompatibel ist, dessen Class-File-Version 67 ist.

## Lösung

Diese Pull Request enthält folgende Änderungen:

1. Aktualisierung der JaCoCo-Version auf 0.8.12, die mit Java 23 kompatibel ist
2. Optimierte Konfiguration der JaCoCo-Plugin-Ausschlüsse
3. Hinzufügen eines neuen Maven-Profils `skip-jacoco`, um die JaCoCo-Instrumentierung bei Bedarf zu überspringen

Diese Änderungen sollten das Problem beheben und die Tests erfolgreich ausführen lassen, ohne die Fehlermeldung bezüglich der nicht unterstützten Class-File-Version.
