### PR TITLE
Spring Bean-Konflikt beheben

### DIFF
--- a/src/main/java/com/example/motion/config/MotionConfig.java
+++ b/src/main/java/com/example/motion/config/MotionConfig.java
@@ -5,16 +5,26 @@ import com.example.motion.sys.behavior.IMotionLayer;
 import com.example.motion.sys.data.InMemoryMotionDataRepository;
 import com.example.motion.sys.data.IMotionDataRepository;
 import com.example.motion.services.CharacterMotionServiceImpl;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 @Configuration
 public class MotionConfig {
 
+    /**
+     * Diese Bean-Definition wird entfernt, da die Klasse InMemoryMotionDataRepository
+     * bereits mit @Repository annotiert ist und automatisch als Bean erkannt wird.
+     * Wenn zwei Implementierungen benötigt werden, können wir eine mit @Primary markieren
+     * oder Qualifier verwenden.
+     */
+    /*
     @Bean
     public IMotionDataRepository motionDataRepository() {
         return new InMemoryMotionDataRepository();
     }
+    */
 
     @Bean
     public ICharacterMotionService characterMotionService(IMotionDataRepository repository) {

--- a/src/main/java/com/example/motion/sys/data/InMemoryMotionDataRepository.java
+++ b/src/main/java/com/example/motion/sys/data/InMemoryMotionDataRepository.java
@@ -2,6 +2,7 @@ package com.example.motion.sys.data;
 
 import com.example.motion.sys.model.AnimationData;
 import com.example.motion.sys.model.MotionState;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
@@ -11,6 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Repository
+@Primary
 public class InMemoryMotionDataRepository implements IMotionDataRepository {
     private final Map<UUID, MotionState> motionStates;
     private final Map<UUID, List<MotionState>> motionHistories;


### PR DESCRIPTION
## Problem

Die Anwendung schlägt mit folgendem Fehler fehl:
```
Parameter 0 of method characterMotionService in com.example.motion.config.MotionConfig required a single bean, but 2 were found:
  - inMemoryMotionDataRepository: defined in file [.../InMemoryMotionDataRepository.class]
  - motionDataRepository: defined by method 'motionDataRepository' in class path resource [com/example/motion/config/MotionConfig.class]
```

Das Problem besteht darin, dass es zwei Bean-Definitionen für das `IMotionDataRepository`-Interface gibt:
1. Die Klasse `InMemoryMotionDataRepository` ist mit `@Repository` annotiert
2. Die Methode `motionDataRepository()` in `MotionConfig` erstellt eine weitere Bean

## Lösung

Diese Pull Request enthält folgende Änderungen:

1. Entfernung der redundanten Bean-Definition in `MotionConfig`
2. Hinzufügen der `@Primary`-Annotation zur `InMemoryMotionDataRepository`-Klasse

Durch diese Änderungen wird sichergestellt, dass Spring eindeutig bestimmen kann, welche Bean für die Dependency Injection verwendet werden soll, wenn mehrere Implementierungen des `IMotionDataRepository`-Interfaces vorhanden sind.

## Alternativen

Eine alternative Lösung wäre die Verwendung von `@Qualifier`, um explizit anzugeben, welche Bean-Implementierung verwendet werden soll. Diese Lösung wurde jedoch nicht gewählt, da sie zusätzliche Änderungen an allen Injektionspunkten erfordern würde.